### PR TITLE
Fix CommonJS and AMD module export

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,9 @@ module.exports = {
       },
     },
   },
+  'globals': {
+    'module': 'readonly',  // For CommonJS/AMD export
+  },
   'rules': {
     // Deprecated and replaced by community jsdoc plugin:
     'valid-jsdoc': 'off',

--- a/index.js
+++ b/index.js
@@ -329,9 +329,7 @@ EmeEncryptionSchemePolyfill.originalRMKSA_;
 // Support for CommonJS and AMD module formats.
 /** @suppress {undefinedVars} */
 (() => {
-  // eslint-disable-next-line no-undef
   if (typeof module !== 'undefined' && module.exports) {
-    // eslint-disable-next-line no-undef
     module.exports = EmeEncryptionSchemePolyfill;
   }
 })();

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@
  * it assumes support for the historically-supported schemes of each well-known
  * key system.
  *
- * In source form, this is compatible with the Closure Compiler and the CommonJS
- * module format.  It can also be directly included via a script tag.
+ * In source form, this is compatible with the Closure Compiler, CommonJS, and
+ * AMD module formats.  It can also be directly included via a script tag.
  *
  * The minified bundle is a standalone module compatible with the CommonJS and
  * AMD module formats, and can also be directly included via a script tag.
@@ -326,11 +326,12 @@ class EmeEncryptionSchemePolyfillMediaKeySystemAccess {
  */
 EmeEncryptionSchemePolyfill.originalRMKSA_;
 
-// Support for CommonJS module format.
+// Support for CommonJS and AMD module formats.
 /** @suppress {undefinedVars} */
 (() => {
-  if (typeof exports !== 'undefined') {
+  // eslint-disable-next-line no-undef
+  if (typeof module !== 'undefined' && module.exports) {
     // eslint-disable-next-line no-undef
-    exports = EmeEncryptionSchemePolyfill;
+    module.exports = EmeEncryptionSchemePolyfill;
   }
 })();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "lint": "eslint index.js",
-    "build": "browserify index.js -s EncryptionSchemePolyfill -t babelify -t stripify -p tinyify -p browserify-header -o dist/eme-encryption-scheme-polyfill.js",
+    "build": "browserify index.js -s EmeEncryptionSchemePolyfill -t babelify -t stripify -p tinyify -p browserify-header -o dist/eme-encryption-scheme-polyfill.js",
     "prepublishOnly": "npm run-script lint && npm run-script build"
   },
   "devDependencies": {


### PR DESCRIPTION
Overwriting "exports" fails to export the thing.  Instead, overwrite
module.exports.

Also, the build script had the wrong name in the stand-alone module
argument to browserify.

Closes #2