### PR TITLE
Fix mis-translation by babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,22 +185,19 @@ class EmeEncryptionSchemePolyfill {
           !filteredVideoCapabilities.length) {
         // We eliminated all of the video capabilities, so this configuration
         // is unusable.
-        continue;
-      }
-      if (configuration.audioCapabilities &&
+      } else if (configuration.audioCapabilities &&
           configuration.audioCapabilities.length &&
           !filteredAudioCapabilities.length) {
         // We eliminated all of the audio capabilities, so this configuration
         // is unusable.
-        continue;
+      } else {
+        // Recreate a clone of the configuration and modify that.  This way, we
+        // don't modify the application-provided config objects.
+        const clonedConfiguration = Object.assign({}, configuration);
+        clonedConfiguration.videoCapabilities = filteredVideoCapabilities;
+        clonedConfiguration.audioCapabilities = filteredAudioCapabilities;
+        filteredSupportedConfigurations.push(clonedConfiguration);
       }
-
-      // Recreate a clone of the configuration and modify that.  This way, we
-      // don't modify the application-provided config objects.
-      const clonedConfiguration = Object.assign({}, configuration);
-      clonedConfiguration.videoCapabilities = filteredVideoCapabilities;
-      clonedConfiguration.audioCapabilities = filteredAudioCapabilities;
-      filteredSupportedConfigurations.push(clonedConfiguration);
     }
 
     if (!filteredSupportedConfigurations.length) {


### PR DESCRIPTION
Babel was turning the "continue" statements in the for-of loop into
"return" statements.  If this were inside an anonymous function, this
would make sense, but it was not.  This would cause certain inputs to
cause a return of undefined in the compiled bundle.

This restructures the source to use if/else if/else instead of
continue in the loop.

Closes #3