### PR TITLE
Consistently use window. to refer to DOM elements

### DIFF
--- a/demo/query.js
+++ b/demo/query.js
@@ -105,15 +105,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       const result = await navigator.mediaCapabilities.decodingInfo(config);
-      results.textContent = formatObjectToString(result);
+      window.results.textContent = formatObjectToString(result);
 
       const mksa = result.keySystemAccess;
       if (mksa) {
-        results.textContent += '\n' +
+        window.results.textContent += '\n' +
             formatObjectToString(mksa.getConfiguration());
       }
     } catch (error) {
-      results.textContent = formatObjectToString({error: error.message});
+      window.results.textContent = formatObjectToString({error: error.message});
     }
   });  // mcRun click listener
 });  // DOMContentLoaded listener


### PR DESCRIPTION
This makes the demo code clearer.