### PR TITLE
Add check for capability existence to hasEncryptionScheme

### DIFF
--- a/index.js
+++ b/index.js
@@ -488,7 +488,7 @@ function hasEncryptionScheme(mediaKeySystemAccess) {
   // If supported by the browser, the encryptionScheme field must appear in
   // the returned configuration, regardless of whether or not it was
   // specified in the supportedConfigurations given by the application.
-  if (firstCapability['encryptionScheme'] !== undefined) {
+  if (firstCapability && firstCapability['encryptionScheme'] !== undefined) {
     return true;
   }
   return false;


### PR DESCRIPTION
Hi,

When there is no video or audio capabilities hasEncryptionScheme check will throw an error.
Microsoft Edge 42.17134.1098.0 has the issue with incorrect capabilities, so the issue was reproduced on the demo page

config:
![image](https://user-images.githubusercontent.com/31937370/75057467-218a1780-54ea-11ea-8ddb-36c0866f3afb.png)

After executing 

```
navigator.requestMediaKeySystemAccess('com.microsoft.playready', configs).then(console.log).catch(console.error)
```

the error:
![image](https://user-images.githubusercontent.com/31937370/75057020-24383d00-54e9-11ea-8494-e1f8d06bb85d.png)

after changes in this mr the result is correct
![image](https://user-images.githubusercontent.com/31937370/75057320-ce17c980-54e9-11ea-91d4-da4877e3e4e0.png)

This MR will add the check for capability existence, so the support of DRM can be checked correctly 


