### PR TITLE
fix: Support browsers with clear MCap but no encrypted MCap

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,9 +417,8 @@ class McEncryptionSchemePolyfill {
       videoCapabilities.push(capability);
     }
 
-    const mediaCapInitDataType = mediaCapKeySystemConfig.initDataType;
-    const initDataTypes = mediaCapInitDataType && mediaCapInitDataType.length ?
-        [mediaCapInitDataType] : [];
+    const initDataTypes = mediaCapKeySystemConfig.initDataType ?
+        [mediaCapKeySystemConfig.initDataType] : [];
 
     /** @type {!MediaKeySystemConfiguration} */
     const mediaKeySystemConfig = {

--- a/index.js
+++ b/index.js
@@ -280,8 +280,7 @@ class McEncryptionSchemePolyfill {
         await McEncryptionSchemePolyfill.originalDecodingInfo_.call(
             this, requestedConfiguration);
 
-    if (!requestedConfiguration.keySystemConfiguration ||
-        !capabilities.keySystemAccess) {
+    if (!requestedConfiguration.keySystemConfiguration) {
       // This was not a query regarding encrypted content.  The results are
       // valid, but won't tell us anything about native support for
       // encryptionScheme.  Just return the results.
@@ -290,7 +289,7 @@ class McEncryptionSchemePolyfill {
 
     const mediaKeySystemAccess = capabilities.keySystemAccess;
 
-    if (hasEncryptionScheme(mediaKeySystemAccess)) {
+    if (mediaKeySystemAccess && hasEncryptionScheme(mediaKeySystemAccess)) {
       // The browser supports the encryptionScheme field!
       // No need for a patch.  Revert back to the original implementation.
       console.debug('McEncryptionSchemePolyfill: ' +
@@ -302,15 +301,26 @@ class McEncryptionSchemePolyfill {
       return capabilities;
     }
 
-    // If we land here, the browser does _not_ support the encryptionScheme
-    // field.  So we install another patch to check the encryptionScheme field
-    // in future calls.
+    // If we land here, the browser does _not_ support the mediaKeySystemAccess
+    // field or the encryptionScheme field.  So we install another patch to
+    // check the mediaKeySystemAccess or encryptionScheme field in future calls.
     console.debug('McEncryptionSchemePolyfill: ' +
         'No native encryptionScheme support found. '+
         'Patching encryptionScheme support.');
     // eslint-disable-next-line require-atomic-updates
     navigator.mediaCapabilities.decodingInfo =
         McEncryptionSchemePolyfill.polyfillDecodingInfo_;
+
+    if (!mediaKeySystemAccess) {
+      const mediaKeySystemConfig =
+          McEncryptionSchemePolyfill.convertToMediaKeySystemConfig_(
+              requestedConfiguration);
+      capabilities.keySystemAccess =
+          await navigator.requestMediaKeySystemAccess(
+              requestedConfiguration.keySystemConfiguration.keySystem,
+              [mediaKeySystemConfig]);
+      return capabilities;
+    }
 
     // The results we have may not be valid.  Run the query again through our
     // polyfill.
@@ -378,9 +388,63 @@ class McEncryptionSchemePolyfill {
       capabilities.keySystemAccess =
           new EmeEncryptionSchemePolyfillMediaKeySystemAccess(
               capabilities.keySystemAccess, supportedScheme);
+    } else if (requestedConfiguration.keySystemConfiguration) {
+      const mediaKeySystemConfig =
+          McEncryptionSchemePolyfill.convertToMediaKeySystemConfig_(
+              requestedConfiguration);
+      capabilities.keySystemAccess =
+          await navigator.requestMediaKeySystemAccess(
+              requestedConfiguration.keySystemConfiguration.keySystem,
+              [mediaKeySystemConfig]);
     }
 
     return capabilities;
+  }
+
+  /**
+   * Convert the MediaDecodingConfiguration object to a
+   * MediaKeySystemConfiguration object.
+   * @param {!MediaDecodingConfiguration} decodingConfig
+   * @return {!MediaKeySystemConfiguration}
+   */
+  static convertToMediaKeySystemConfig_(decodingConfig) {
+    const mediaCapkeySystemConfig = decodingConfig.keySystemConfiguration;
+    const audioCapabilities = [];
+    const videoCapabilities = [];
+
+    if (mediaCapkeySystemConfig.audio) {
+      const capability = {
+        robustness: mediaCapkeySystemConfig.audio.robustness || '',
+        contentType: decodingConfig.audio.contentType,
+      };
+      audioCapabilities.push(capability);
+    }
+
+    if (mediaCapkeySystemConfig.video) {
+      const capability = {
+        robustness: mediaCapkeySystemConfig.video.robustness || '',
+        contentType: decodingConfig.video.contentType,
+      };
+      videoCapabilities.push(capability);
+    }
+
+    /** @type {!MediaKeySystemConfiguration} */
+    const mediaKeySystemConfig = {
+      initDataTypes: [mediaCapkeySystemConfig.initDataType],
+      distinctiveIdentifier: mediaCapkeySystemConfig.distinctiveIdentifier,
+      persistentState: mediaCapkeySystemConfig.persistentState,
+      sessionTypes: mediaCapkeySystemConfig.sessionTypes,
+    };
+
+    // Only add the audio video capablities if they have valid data.
+    // Otherwise the query will fail.
+    if (audioCapabilities.length) {
+      mediaKeySystemConfig.audioCapabilities = audioCapabilities;
+    }
+    if (videoCapabilities.length) {
+      mediaKeySystemConfig.videoCapabilities = videoCapabilities;
+    }
+    return mediaKeySystemConfig;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -311,17 +311,6 @@ class McEncryptionSchemePolyfill {
     navigator.mediaCapabilities.decodingInfo =
         McEncryptionSchemePolyfill.polyfillDecodingInfo_;
 
-    if (!mediaKeySystemAccess) {
-      const mediaKeySystemConfig =
-          McEncryptionSchemePolyfill.convertToMediaKeySystemConfig_(
-              requestedConfiguration);
-      capabilities.keySystemAccess =
-          await navigator.requestMediaKeySystemAccess(
-              requestedConfiguration.keySystemConfiguration.keySystem,
-              [mediaKeySystemConfig]);
-      return capabilities;
-    }
-
     // The results we have may not be valid.  Run the query again through our
     // polyfill.
     return McEncryptionSchemePolyfill.polyfillDecodingInfo_.call(
@@ -408,32 +397,36 @@ class McEncryptionSchemePolyfill {
    * @return {!MediaKeySystemConfiguration}
    */
   static convertToMediaKeySystemConfig_(decodingConfig) {
-    const mediaCapkeySystemConfig = decodingConfig.keySystemConfiguration;
+    const mediaCapKeySystemConfig = decodingConfig.keySystemConfiguration;
     const audioCapabilities = [];
     const videoCapabilities = [];
 
-    if (mediaCapkeySystemConfig.audio) {
+    if (mediaCapKeySystemConfig.audio) {
       const capability = {
-        robustness: mediaCapkeySystemConfig.audio.robustness || '',
+        robustness: mediaCapKeySystemConfig.audio.robustness || '',
         contentType: decodingConfig.audio.contentType,
       };
       audioCapabilities.push(capability);
     }
 
-    if (mediaCapkeySystemConfig.video) {
+    if (mediaCapKeySystemConfig.video) {
       const capability = {
-        robustness: mediaCapkeySystemConfig.video.robustness || '',
+        robustness: mediaCapKeySystemConfig.video.robustness || '',
         contentType: decodingConfig.video.contentType,
       };
       videoCapabilities.push(capability);
     }
 
+    const mediaCapInitDataType = mediaCapKeySystemConfig.initDataType;
+    const initDataTypes = mediaCapInitDataType && mediaCapInitDataType.length :
+        [mediaCapInitDataType] ? [];
+
     /** @type {!MediaKeySystemConfiguration} */
     const mediaKeySystemConfig = {
-      initDataTypes: [mediaCapkeySystemConfig.initDataType],
-      distinctiveIdentifier: mediaCapkeySystemConfig.distinctiveIdentifier,
-      persistentState: mediaCapkeySystemConfig.persistentState,
-      sessionTypes: mediaCapkeySystemConfig.sessionTypes,
+      initDataTypes: initDataTypes,
+      distinctiveIdentifier: mediaCapKeySystemConfig.distinctiveIdentifier,
+      persistentState: mediaCapKeySystemConfig.persistentState,
+      sessionTypes: mediaCapKeySystemConfig.sessionTypes,
     };
 
     // Only add the audio video capablities if they have valid data.

--- a/index.js
+++ b/index.js
@@ -418,8 +418,8 @@ class McEncryptionSchemePolyfill {
     }
 
     const mediaCapInitDataType = mediaCapKeySystemConfig.initDataType;
-    const initDataTypes = mediaCapInitDataType && mediaCapInitDataType.length :
-        [mediaCapInitDataType] ? [];
+    const initDataTypes = mediaCapInitDataType && mediaCapInitDataType.length ?
+        [mediaCapInitDataType] : [];
 
     /** @type {!MediaKeySystemConfiguration} */
     const mediaKeySystemConfig = {


### PR DESCRIPTION
Check if native `mediaCapabilities.decodingInfo` result has the `keySystemAccess` property for encrypted content. If not, we should patch that.