### PR TITLE
deps: Update eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "babelify": "^10.0.0",
     "browserify": "^16.5.0",
     "browserify-header": "^1.0.1",
-    "eslint": "^7.18.0",
+    "eslint": "^8.8.0",
     "eslint-config-google": "^0.14.0",
-    "eslint-plugin-jsdoc": "^18.4.1",
-    "google-closure-compiler": "latest",
+    "eslint-plugin-jsdoc": "^37.8.2",
+    "google-closure-compiler": "^20200101.0.0",
     "stripify": "^6.0.0",
     "tinyify": "^2.5.2"
   },


### PR DESCRIPTION
The Closure Compiler version has been set back to a working version
instead of "latest".  A full update will require more changes.